### PR TITLE
Generalized temporal probing so it can be launched for different models

### DIFF
--- a/scripts/probes/train_temporal_probes_caa.py
+++ b/scripts/probes/train_temporal_probes_caa.py
@@ -77,7 +77,7 @@ def extract_activations(model, decoder_blocks, tokenizer, prompt):
 
     def hook_fn(layer_idx):
         def hook(module, input, output):
-            # output is either tuple of hidden_states or hidden_states
+            # output is either tuple (hidden_states,...) or just hidden_states
             # hidden_states shape: (batch, seq_len, hidden_dim)
             # Take last token activation
             if isinstance(output, tuple):


### PR DESCRIPTION
- Generalizing `scripts/probes/train_temporal_probes_caa.py` to accept different models.
- Should work for `gpt2`, `Qwen/Qwen3-0.6B`, `TinyLlama/TinyLlama-1.1B-Chat-v1.0`.