### PR TITLE
Add scripts/vast: generic vast.ai launcher for GPU experiments

### DIFF
--- a/scripts/vast/README.md
+++ b/scripts/vast/README.md
@@ -1,0 +1,151 @@
+# vast.ai launcher
+
+Generic driver for running GPU experiments on [vast.ai](https://vast.ai).
+Provisions a single instance, rsyncs the current repo, installs a
+PyTorch + ML stack matched to the detected GPU, runs your command, pulls
+results back, and destroys the instance it created.
+
+## Quick start
+
+```bash
+# 1. Put VASTAI_API_KEY in .env (at repo root)
+echo 'VASTAI_API_KEY=<your-key>' >> .env
+
+# 2. Register your local SSH key with the vast account (once):
+vastai create ssh-key "$(cat ~/.ssh/id_rsa.pub)"
+
+# 3. Run any command on a GPU:
+scripts/vast/launch.sh 'python scripts/my_experiment/run.py'
+```
+
+Results land in `./vast_results/<label>_<instance_id>.tar.gz` on your local
+machine.
+
+## Safety invariant: only destroys the instance it created
+
+The launcher is explicit about this because the account may be shared:
+
+- `launch.sh` stores the instance ID only from its own `create instance` call
+- The cleanup `trap` destroys **by explicit ID** (`vastai destroy instance $INSTANCE_ID`)
+- If ID parsing fails, `INSTANCE_ID` is left empty and the trap **skips destroy** rather than running a dangerous default
+- The launcher never calls `destroy all`, never iterates over `show instances`, never destroys anything it didn't itself create
+- Set `LEAVE_INSTANCE=1` to skip the destroy (useful for debugging a failed run)
+
+If you see other instances on the account disappear while running this
+script, it is not from this script. Other places to look: another user on a
+shared account, vast's own eviction of interruptible bids, or credit
+exhaustion auto-stops.
+
+## Configuration
+
+All env vars are optional unless marked required.
+
+| Var | Default | Meaning |
+|---|---|---|
+| `REMOTE_CMD` / `$1` | **required** | command executed on the remote |
+| `VAST_API_KEY` | from `.env` | API key for vast.ai |
+| `GPU_QUERY` | RTX 5090, ≥120 GB disk, reliability ≥0.97 | vast offer filter |
+| `IMAGE` | `pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel` | Docker image for the instance |
+| `MAX_DPH_USD` | `3.00` | refuse offers over this total $/hr |
+| `BUDGET_USD` | `50` | informational — surfaces runtime headroom |
+| `MIN_DISK_GB` | `120` | minimum disk requested |
+| `EXCLUDES` | excludes `.git`, venvs, caches, `results` | rsync exclude args |
+| `INSTALL_DEPS` | `1` | run `bootstrap.sh` before `REMOTE_CMD` |
+| `BOOTSTRAP_EXTRA` | *(empty)* | extra pip packages to install |
+| `PREDOWNLOAD_HF` | *(empty)* | space-separated HF model IDs to pre-fetch |
+| `LABEL` | `vast-launch` | prefix for the pulled results tarball |
+| `LEAVE_INSTANCE` | `0` | `1` = skip destroy, useful for debugging |
+
+## GPU tier examples
+
+```bash
+# Single H100 SXM 80GB (for 30B+ models in bf16)
+GPU_QUERY='gpu_name=H100_SXM num_gpus=1 disk_space>=200 reliability>=0.97 rentable=True' \
+    scripts/vast/launch.sh 'python myexp.py'
+
+# Single A100 40GB (cheap, fits 14B bf16)
+GPU_QUERY='gpu_name=A100 num_gpus=1 disk_space>=120 reliability>=0.97 rentable=True' \
+    scripts/vast/launch.sh 'python myexp.py'
+
+# Cheapest 5090 32GB (great for ≤14B in bf16)
+GPU_QUERY='gpu_name=RTX_5090 num_gpus=1 disk_space>=120 reliability>=0.97 rentable=True' \
+    scripts/vast/launch.sh 'python myexp.py'
+```
+
+## Blackwell / RTX 5090 caveat
+
+**RTX 5090 is Blackwell (`sm_120`)** and needs CUDA 12.8+ wheels. The
+`pytorch/pytorch:2.4.0-cuda12.4` base image ships torch 2.4.0+cu121, which
+has no kernels for `sm_120`. Any CUDA op fails with:
+
+```
+RuntimeError: CUDA error: no kernel image is available for execution on the device
+```
+
+`bootstrap.sh` detects this automatically (reads `nvidia-smi --query-gpu=compute_cap`)
+and force-upgrades to `torch==2.7.1+cu128` on Blackwell. On Ampere/Hopper it
+leaves the image's torch alone. Override with `SKIP_TORCH_UPGRADE=1` if you
+need different behavior.
+
+## Pre-downloading HF models
+
+Model weights can be several GB and re-downloading them on every run is
+wasteful. Pass them via `PREDOWNLOAD_HF`:
+
+```bash
+PREDOWNLOAD_HF='Qwen/Qwen2.5-7B meta-llama/Llama-3.2-1B' \
+    scripts/vast/launch.sh 'python myexp.py'
+```
+
+Files are cached under `$HF_HOME=/workspace/hf_cache`. The cache is
+instance-local (not persisted across instances), so pre-download runs on
+every launch.
+
+## How results get back
+
+Your remote command should write outputs to `./results/` inside the repo.
+`launch.sh` tars `results/` into `/workspace/results.tar.gz` at end-of-run
+and pulls it back to `./vast_results/<label>_<instance_id>.tar.gz`.
+
+If you need a different location, set `RESULTS_REMOTE` (path on the remote)
+and/or `RESULTS_LOCAL_DIR` (directory on your machine).
+
+## Troubleshooting
+
+### "No matching offers"
+
+Your `GPU_QUERY` is too restrictive or `MAX_DPH_USD` is too low. Widen the
+filter or raise the price cap.
+
+### "Could not parse new instance id from create output"
+
+The vast API returned something unexpected. The launcher intentionally aborts
+here — it will **not** try to destroy anything, because it doesn't know what
+ID to target. Check `vastai show instances` manually and clean up if needed.
+
+### SSH hangs / "Connection refused"
+
+The instance is still loading (Docker image pull can take 2–5 minutes on a
+fresh machine). `launch.sh` polls for ~10 minutes; if SSH never comes up,
+something is wrong with the host — destroy and try another offer.
+
+### "expected scalar type Float but found Half/BFloat16" in transformer_lens
+
+Known issue with grouped-query attention models (Qwen 2.x, Llama 3.x) in
+`transformer_lens==3.0.0b3` when loaded in half precision. Workarounds:
+
+- Load in `torch.float32` (costs 2× VRAM)
+- Downgrade to `transformer_lens==2.11.0` (may not support newest models)
+- Patch `calculate_attention_scores` to cast to fp32 before the matmul
+
+### "billing failed" mid-run
+
+Your account credit ran out. Instances auto-stop (not destroy) when billing
+fails — your work is usually preserved on disk and resumes if you add credit
+before vast evicts the instance.
+
+## Files
+
+- `launch.sh` — local driver; search offers → create → rsync → run → pull → destroy
+- `bootstrap.sh` — runs on the remote; detects GPU, installs torch + ML stack, pre-downloads models
+- `README.md` — this file

--- a/scripts/vast/bootstrap.sh
+++ b/scripts/vast/bootstrap.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Runs on the vast.ai instance. Installs a PyTorch + ML stack that matches the
+# detected GPU capability, pre-downloads HF models if requested, and then
+# returns control to launch.sh so it can exec the user command.
+#
+# This script is idempotent: re-running it is safe.
+#
+# Env:
+#   BOOTSTRAP_EXTRA   extra pip packages to install (space-separated)
+#   PREDOWNLOAD_HF    HF model IDs to pre-download (space-separated)
+#   SKIP_TORCH_UPGRADE  if 1, do not touch torch (trust the base image)
+
+set -euo pipefail
+
+BOOTSTRAP_EXTRA="${BOOTSTRAP_EXTRA:-}"
+PREDOWNLOAD_HF="${PREDOWNLOAD_HF:-}"
+SKIP_TORCH_UPGRADE="${SKIP_TORCH_UPGRADE:-0}"
+
+echo "[bootstrap] === GPU detection ==="
+nvidia-smi --query-gpu=name,compute_cap,memory.total --format=csv 2>/dev/null || {
+    echo "[bootstrap] WARN: no nvidia-smi"
+}
+
+CC="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ' || true)"
+echo "[bootstrap] compute_capability=$CC"
+
+# Torch wheel selection.
+#
+#   Blackwell (sm_120, RTX 5090, B100/B200) requires CUDA 12.8 wheels.
+#   Hopper (sm_90, H100, H200) works with CUDA 12.1+ wheels.
+#   Ampere (sm_80/86, A100/A6000/3090/4090) works with CUDA 11.8+ wheels.
+#
+# The pytorch/pytorch:2.4.0 base image ships torch 2.4.0+cu121 which has NO
+# kernels for sm_120. On Blackwell this fails with:
+#   RuntimeError: CUDA error: no kernel image is available for execution on the device
+# Fix: force-upgrade torch to 2.7.1 from the cu128 index.
+NEED_TORCH_UPGRADE=0
+case "$CC" in
+    12.0|12.*)
+        NEED_TORCH_UPGRADE=1
+        TORCH_VERSION="2.7.1"
+        TORCH_INDEX="https://download.pytorch.org/whl/cu128"
+        echo "[bootstrap] Blackwell GPU detected (sm_$CC) -> torch==$TORCH_VERSION+cu128"
+        ;;
+    *)
+        echo "[bootstrap] compute_cap=$CC -> using base image torch (no upgrade)"
+        ;;
+esac
+
+if [ "$SKIP_TORCH_UPGRADE" = "1" ]; then
+    NEED_TORCH_UPGRADE=0
+fi
+
+echo "[bootstrap] === installing base deps ==="
+if [ "$NEED_TORCH_UPGRADE" = "1" ]; then
+    pip uninstall -y torch torchvision 2>&1 | tail -3 || true
+    pip install --no-cache-dir --index-url "$TORCH_INDEX" \
+        "torch==$TORCH_VERSION" "torchvision" 2>&1 | tail -5
+fi
+
+# Pin transformers to a version compatible with transformer_lens 3.x.
+# 3.0.0b3 requires transformers>=4.56. If your experiment uses a different
+# transformer_lens version, override by setting BOOTSTRAP_EXTRA.
+pip install --no-cache-dir \
+    "transformers==4.56.2" \
+    "transformer_lens==3.0.0b3" \
+    "scikit-learn" "scipy" "matplotlib" "numpy" "pandas" "tqdm" \
+    "accelerate" "einops" \
+    2>&1 | tail -10
+
+if [ -n "$BOOTSTRAP_EXTRA" ]; then
+    echo "[bootstrap] === extra deps: $BOOTSTRAP_EXTRA ==="
+    # shellcheck disable=SC2086
+    pip install --no-cache-dir $BOOTSTRAP_EXTRA 2>&1 | tail -5
+fi
+
+echo "[bootstrap] === sanity check ==="
+python - <<'PY'
+import torch
+print(f"torch={torch.__version__}, cuda_available={torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"gpu={torch.cuda.get_device_name(0)}")
+    print(f"compute_cap={torch.cuda.get_device_capability(0)}")
+    try:
+        x = torch.zeros(1, device='cuda') + 1
+        print(f"gpu_op_ok={x.item()}")
+    except Exception as e:
+        print(f"GPU_OP_FAILED: {type(e).__name__}: {e}")
+        raise SystemExit(1)
+try:
+    import transformers, transformer_lens  # noqa
+    print(f"transformers={transformers.__version__}")
+except Exception as e:
+    print(f"IMPORT_FAILED: {e}")
+    raise SystemExit(1)
+PY
+
+if [ -n "$PREDOWNLOAD_HF" ]; then
+    echo "[bootstrap] === predownloading HF models: $PREDOWNLOAD_HF ==="
+    for m in $PREDOWNLOAD_HF; do
+        echo "[bootstrap] fetching $m"
+        python -c "
+from transformers import AutoModelForCausalLM, AutoTokenizer
+AutoTokenizer.from_pretrained('$m')
+AutoModelForCausalLM.from_pretrained('$m', torch_dtype='auto')
+" 2>&1 | tail -3
+    done
+fi
+
+echo "[bootstrap] === done ==="

--- a/scripts/vast/launch.sh
+++ b/scripts/vast/launch.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Generic vast.ai launcher for GPU experiments.
+#
+# Provisions a single vast.ai instance, rsyncs the current repo to it, runs a
+# user-supplied command on the remote, pulls a results tarball back, and
+# destroys the instance it created.
+#
+# CRITICAL SAFETY INVARIANT — shared accounts:
+#   This script ONLY destroys the instance it created itself. It never issues
+#   `destroy all`, never iterates over existing instances, and never touches
+#   any instance ID it didn't produce from its own `create instance` call.
+#   If the create step fails to return an ID, the script aborts WITHOUT calling
+#   destroy. The cleanup trap re-checks that INSTANCE_ID is set and non-empty.
+#
+# Usage:
+#   scripts/vast/launch.sh <remote-command>
+#
+# Example:
+#   REMOTE_CMD='python scripts/my_experiment/run.py --smoke' \
+#       scripts/vast/launch.sh
+#
+#   GPU_QUERY='gpu_name=H100_SXM num_gpus=1 disk_space>=200' \
+#   BUDGET_USD=50 \
+#       scripts/vast/launch.sh "python scripts/my_experiment/run.py"
+#
+# Env vars:
+#   REMOTE_CMD        command string to execute on the remote (required, or $1)
+#   VAST_API_KEY      (required) — read from .env if not set
+#   GPU_QUERY         default 'gpu_name=RTX_5090 num_gpus=1 disk_space>=120 reliability>=0.97 rentable=True'
+#   IMAGE             default pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel (bootstrap.sh upgrades torch for Blackwell)
+#   MAX_DPH_USD       default 3.00 — refuse offers above this total price/hour
+#   BUDGET_USD        default 50 — informational, surfaced at launch time
+#   MIN_DISK_GB       default 120 — minimum instance disk (and --disk requested)
+#   EXCLUDES          default excludes for rsync (.git, venvs, caches, results)
+#   RESULTS_REMOTE    default /workspace/results.tar.gz
+#   RESULTS_LOCAL     default $PWD/vast_results/results_<instance_id>.tar.gz
+#   INSTALL_DEPS      default 1 — run bootstrap.sh to install deps before REMOTE_CMD
+#   BOOTSTRAP_EXTRA   extra pip packages to install (space-separated)
+#   PREDOWNLOAD_HF    space-separated HF model IDs to pre-download before REMOTE_CMD
+#   LABEL             default "vast-launch" — prefix for result files
+#   LEAVE_INSTANCE    default 0 — if 1, skip destroy at end (useful for debugging)
+#
+# Exits:
+#   0 on success (instance destroyed)
+#   non-zero on any failure (cleanup trap still runs; instance still destroyed
+#   if it was created, unless LEAVE_INSTANCE=1)
+
+set -euo pipefail
+
+REMOTE_CMD="${REMOTE_CMD:-${1:-}}"
+if [ -z "$REMOTE_CMD" ]; then
+    echo "ERROR: REMOTE_CMD (or first positional arg) required" >&2
+    echo "  example: $0 'python scripts/my_experiment/run.py --smoke'" >&2
+    exit 2
+fi
+
+REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_DIR"
+
+# ---- api key ----
+if [ -z "${VAST_API_KEY:-}" ]; then
+    ENV_FILE="$REPO_DIR/.env"
+    if [ ! -f "$ENV_FILE" ] && [ -f "$HOME/projects/temporal/temporal-awareness/.env" ]; then
+        ENV_FILE="$HOME/projects/temporal/temporal-awareness/.env"
+    fi
+    if [ -f "$ENV_FILE" ]; then
+        VAST_API_KEY="$(grep -E '^VASTAI_API_KEY=' "$ENV_FILE" | cut -d= -f2- | tr -d '"' | tr -d "'" | head -1)"
+    fi
+fi
+if [ -z "${VAST_API_KEY:-}" ]; then
+    echo "ERROR: VAST_API_KEY not set and not found in .env" >&2
+    exit 2
+fi
+export VAST_API_KEY
+
+# ---- defaults ----
+GPU_QUERY="${GPU_QUERY:-gpu_name=RTX_5090 num_gpus=1 disk_space>=120 reliability>=0.97 rentable=True}"
+IMAGE="${IMAGE:-pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel}"
+MAX_DPH_USD="${MAX_DPH_USD:-3.00}"
+BUDGET_USD="${BUDGET_USD:-50}"
+MIN_DISK_GB="${MIN_DISK_GB:-120}"
+EXCLUDES="${EXCLUDES:---exclude=.git --exclude=.venv* --exclude=venv --exclude=__pycache__ --exclude=*.tar.gz --exclude=results --exclude=spd_repo}"
+RESULTS_REMOTE="${RESULTS_REMOTE:-/workspace/results.tar.gz}"
+INSTALL_DEPS="${INSTALL_DEPS:-1}"
+BOOTSTRAP_EXTRA="${BOOTSTRAP_EXTRA:-}"
+PREDOWNLOAD_HF="${PREDOWNLOAD_HF:-}"
+LABEL="${LABEL:-vast-launch}"
+LEAVE_INSTANCE="${LEAVE_INSTANCE:-0}"
+
+# ---- vastai CLI ----
+VASTAI_VENV="${VASTAI_VENV:-$HOME/.cache/vastai-venv}"
+if [ ! -x "$VASTAI_VENV/bin/vastai" ]; then
+    python3 -m venv "$VASTAI_VENV"
+    "$VASTAI_VENV/bin/pip" install --quiet --upgrade pip
+    "$VASTAI_VENV/bin/pip" install --quiet vastai
+fi
+VASTAI="$VASTAI_VENV/bin/vastai"
+"$VASTAI" set api-key "$VAST_API_KEY" >/dev/null
+
+# ---- safety: track instance we create; cleanup only destroys that one ----
+INSTANCE_ID=""
+cleanup() {
+    local rc=$?
+    if [ -z "$INSTANCE_ID" ]; then
+        echo "[launch] cleanup: no instance was created, nothing to destroy."
+        return $rc
+    fi
+    if [ "$LEAVE_INSTANCE" = "1" ]; then
+        echo "[launch] cleanup: LEAVE_INSTANCE=1, keeping instance $INSTANCE_ID"
+        echo "[launch]   destroy manually: $VASTAI destroy instance $INSTANCE_ID"
+        return $rc
+    fi
+    echo "[launch] cleanup: destroying instance $INSTANCE_ID (and only this one)"
+    # Explicit by-ID destroy. NEVER use `destroy all` or any variant that
+    # would touch other instances on this (possibly shared) account.
+    "$VASTAI" destroy instance "$INSTANCE_ID" 2>&1 || \
+        echo "[launch] WARN: destroy instance $INSTANCE_ID returned non-zero; verify manually"
+    return $rc
+}
+trap cleanup EXIT INT TERM
+
+# ---- search offers ----
+echo "[launch] searching offers: $GPU_QUERY"
+OFFERS_RAW="$("$VASTAI" search offers "$GPU_QUERY" -o dph_total --raw 2>&1 || true)"
+CHOSEN="$(python3 - <<'PY' <<<"$OFFERS_RAW"
+import json, os, sys
+try:
+    offers = json.loads(sys.stdin.read())
+except Exception as e:
+    print(f"PARSE_ERR: {e}", file=sys.stderr); sys.exit(2)
+max_dph = float(os.environ.get("MAX_DPH_USD", "3.0"))
+best = None
+for o in offers:
+    dph = float(o.get("dph_total", 0) or 0)
+    if dph <= 0 or dph > max_dph:
+        continue
+    if not o.get("rentable", True):
+        continue
+    if best is None or dph < float(best.get("dph_total", 0)):
+        best = o
+if not best:
+    print("NONE")
+else:
+    print(f"{best['id']} {best.get('dph_total',0):.4f} {best.get('gpu_name','?')} {best.get('disk_space',0)}")
+PY
+)"
+
+if [ "$CHOSEN" = "NONE" ] || [ -z "$CHOSEN" ]; then
+    echo "ERROR: no offers under \$$MAX_DPH_USD/hr matching: $GPU_QUERY" >&2
+    exit 1
+fi
+
+OFFER_ID="$(echo "$CHOSEN" | awk '{print $1}')"
+OFFER_DPH="$(echo "$CHOSEN" | awk '{print $2}')"
+OFFER_GPU="$(echo "$CHOSEN" | awk '{print $3}')"
+OFFER_DISK="$(echo "$CHOSEN" | awk '{print $4}')"
+echo "[launch] picked offer $OFFER_ID: \$${OFFER_DPH}/hr, $OFFER_GPU, ${OFFER_DISK}GB disk"
+python3 -c "
+dph=float('$OFFER_DPH'); budget=float('$BUDGET_USD')
+print(f'[launch] budget=\${budget:.2f} -> {budget/dph:.1f}h of runtime headroom')
+"
+
+# ---- create instance ----
+echo "[launch] creating instance (image=$IMAGE, disk=${MIN_DISK_GB}GB)"
+CREATE_OUT="$("$VASTAI" create instance "$OFFER_ID" --image "$IMAGE" --disk "$MIN_DISK_GB" --ssh 2>&1)"
+echo "[launch] create output: $CREATE_OUT"
+INSTANCE_ID="$(echo "$CREATE_OUT" | python3 -c "
+import re, sys
+text = sys.stdin.read()
+m = re.search(r\"'new_contract': (\d+)\", text)
+if m:
+    print(m.group(1))
+" || true)"
+
+if [ -z "$INSTANCE_ID" ]; then
+    echo "ERROR: could not parse new instance id from create output" >&2
+    echo "  raw: $CREATE_OUT" >&2
+    INSTANCE_ID=""  # ensure cleanup() sees empty and does NOT try to destroy
+    exit 1
+fi
+echo "[launch] created instance $INSTANCE_ID"
+
+# ---- wait for running status + SSH ----
+echo "[launch] waiting for instance to reach running state..."
+SSH_HOST=""; SSH_PORT=""
+for i in $(seq 1 60); do
+    STATUS_LINE="$("$VASTAI" show instance "$INSTANCE_ID" --raw 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(d.get('actual_status','unknown'), d.get('ssh_host','') or '', d.get('ssh_port','') or '')
+except Exception:
+    print('unknown  ')
+" || echo 'unknown  ')"
+    ACTUAL="$(echo "$STATUS_LINE" | awk '{print $1}')"
+    SSH_HOST="$(echo "$STATUS_LINE" | awk '{print $2}')"
+    SSH_PORT="$(echo "$STATUS_LINE" | awk '{print $3}')"
+    echo "  [$i/60] actual_status=$ACTUAL ssh=$SSH_HOST:$SSH_PORT"
+    if [ "$ACTUAL" = "running" ] && [ -n "$SSH_HOST" ] && [ "$SSH_HOST" != "None" ]; then
+        break
+    fi
+    sleep 10
+done
+
+if [ "$ACTUAL" != "running" ] || [ -z "$SSH_HOST" ]; then
+    echo "ERROR: instance $INSTANCE_ID did not become ready" >&2
+    exit 1
+fi
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -p $SSH_PORT"
+SSH="ssh $SSH_OPTS root@$SSH_HOST"
+
+# ---- wait for sshd actually accepting connections ----
+for i in $(seq 1 12); do
+    if $SSH -o ConnectTimeout=5 'echo ok' >/dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+done
+
+echo "[launch] rsyncing repo to instance"
+$SSH "mkdir -p /workspace/repo"
+rsync -az --delete -e "ssh $SSH_OPTS" $EXCLUDES "$REPO_DIR/" "root@$SSH_HOST:/workspace/repo/"
+
+# ---- bootstrap (install deps) then run the user command ----
+REMOTE_SCRIPT=/tmp/vast_remote_run.$$.sh
+cat > "$REMOTE_SCRIPT" <<REMOTE_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace/repo
+export PYTHONPATH="/workspace/repo:\${PYTHONPATH:-}"
+export HF_HOME="\${HF_HOME:-/workspace/hf_cache}"
+
+if [ "${INSTALL_DEPS}" = "1" ] && [ -f scripts/vast/bootstrap.sh ]; then
+    BOOTSTRAP_EXTRA='${BOOTSTRAP_EXTRA}' PREDOWNLOAD_HF='${PREDOWNLOAD_HF}' bash scripts/vast/bootstrap.sh
+fi
+
+echo "[remote] === running user command ==="
+${REMOTE_CMD}
+rc=\$?
+echo "[remote] user command exited with rc=\$rc"
+
+echo "[remote] === packaging results -> ${RESULTS_REMOTE} ==="
+tar czf "${RESULTS_REMOTE}" \
+    results 2>/dev/null || echo "[remote] (no results/ dir)"
+ls -la "${RESULTS_REMOTE}" 2>&1 || true
+exit \$rc
+REMOTE_EOF
+chmod +x "$REMOTE_SCRIPT"
+scp -q $SSH_OPTS "$REMOTE_SCRIPT" "root@$SSH_HOST:/workspace/remote_run.sh"
+rm -f "$REMOTE_SCRIPT"
+
+echo "[launch] executing remote command: $REMOTE_CMD"
+set +e
+$SSH "bash /workspace/remote_run.sh" 2>&1
+REMOTE_RC=$?
+set -e
+echo "[launch] remote command rc=$REMOTE_RC"
+
+# ---- pull results ----
+LOCAL_RESULTS_DIR="${RESULTS_LOCAL_DIR:-$REPO_DIR/vast_results}"
+mkdir -p "$LOCAL_RESULTS_DIR"
+LOCAL_TAR="$LOCAL_RESULTS_DIR/${LABEL}_${INSTANCE_ID}.tar.gz"
+echo "[launch] pulling $RESULTS_REMOTE -> $LOCAL_TAR"
+scp -q $SSH_OPTS "root@$SSH_HOST:$RESULTS_REMOTE" "$LOCAL_TAR" || \
+    echo "[launch] WARN: could not pull results tarball from remote"
+ls -la "$LOCAL_TAR" 2>&1 || true
+
+echo "[launch] done (rc=$REMOTE_RC). Cleanup trap will destroy instance $INSTANCE_ID."
+exit $REMOTE_RC


### PR DESCRIPTION
launch.sh provisions a single vast.ai instance, rsyncs the repo, runs a user-supplied command, pulls results, and destroys the instance it created. bootstrap.sh runs on the remote, detects GPU compute capability (auto-upgrades torch to 2.7.1+cu128 on Blackwell / sm_120), installs a transformer_lens-compatible stack, and optionally pre-downloads HF models.

Safety: launcher destroys only the instance ID it parsed from its own create call — never iterates or calls destroy-all, important on shared accounts. Trap aborts destroy when ID parsing fails.

README covers usage, GPU tier examples, the Blackwell caveat, HF pre-download, and common troubleshooting.