### PR TITLE
Tag vast.ai instances with creator identity for shared-account attrib…

### DIFF
--- a/scripts/vast/README.md
+++ b/scripts/vast/README.md
@@ -36,6 +36,24 @@ script, it is not from this script. Other places to look: another user on a
 shared account, vast's own eviction of interruptible bids, or credit
 exhaustion auto-stops.
 
+## Attribution on shared accounts
+
+Every instance created by this launcher is tagged with a vast.ai label of the form:
+
+    <VAST_USER>/<LABEL>/<utc-timestamp>
+
+e.g. `justin/rq4-smoke/20260421T143022Z`. This shows up in `vastai show
+instances` so other users on a shared account can tell whose instance is
+whose at a glance. Filter to your own with `vastai show instances | grep ^justin/`.
+
+Override with:
+
+    VAST_USER=ci-bot LABEL=nightly-sweep scripts/vast/launch.sh '...'
+
+The label is for *visibility only*. Destroy behavior is unchanged: the
+launcher still only destroys the instance ID it created itself, regardless
+of labels.
+
 ## Configuration
 
 All env vars are optional unless marked required.
@@ -55,6 +73,7 @@ All env vars are optional unless marked required.
 | `PREDOWNLOAD_HF` | *(empty)* | space-separated HF model IDs to pre-fetch |
 | `LABEL` | `vast-launch` | prefix for the pulled results tarball |
 | `LEAVE_INSTANCE` | `0` | `1` = skip destroy, useful for debugging |
+| `VAST_USER` | `$USER` | identity tag baked into the instance label for shared-account attribution |
 
 ## GPU tier examples
 

--- a/scripts/vast/launch.sh
+++ b/scripts/vast/launch.sh
@@ -39,6 +39,9 @@
 #   PREDOWNLOAD_HF    space-separated HF model IDs to pre-download before REMOTE_CMD
 #   LABEL             default "vast-launch" — prefix for result files
 #   LEAVE_INSTANCE    default 0 — if 1, skip destroy at end (useful for debugging)
+#   VAST_USER         default $USER — tag included in the instance label so
+#                     other users on a shared account can attribute running
+#                     instances. Falls back to "unknown" if neither is set.
 #
 # Exits:
 #   0 on success (instance destroyed)
@@ -86,6 +89,7 @@ BOOTSTRAP_EXTRA="${BOOTSTRAP_EXTRA:-}"
 PREDOWNLOAD_HF="${PREDOWNLOAD_HF:-}"
 LABEL="${LABEL:-vast-launch}"
 LEAVE_INSTANCE="${LEAVE_INSTANCE:-0}"
+VAST_USER="${VAST_USER:-${USER:-unknown}}"
 
 # ---- vastai CLI ----
 VASTAI_VENV="${VASTAI_VENV:-$HOME/.cache/vastai-venv}"
@@ -161,8 +165,11 @@ print(f'[launch] budget=\${budget:.2f} -> {budget/dph:.1f}h of runtime headroom'
 "
 
 # ---- create instance ----
-echo "[launch] creating instance (image=$IMAGE, disk=${MIN_DISK_GB}GB)"
-CREATE_OUT="$("$VASTAI" create instance "$OFFER_ID" --image "$IMAGE" --disk "$MIN_DISK_GB" --ssh 2>&1)"
+VAST_INSTANCE_LABEL="${VAST_USER}/${LABEL}/$(date -u +%Y%m%dT%H%M%SZ)"
+echo "[launch] creating instance (image=$IMAGE, disk=${MIN_DISK_GB}GB, label=$VAST_INSTANCE_LABEL)"
+CREATE_OUT="$("$VASTAI" create instance "$OFFER_ID" \
+    --image "$IMAGE" --disk "$MIN_DISK_GB" --ssh \
+    --label "$VAST_INSTANCE_LABEL" 2>&1)"
 echo "[launch] create output: $CREATE_OUT"
 INSTANCE_ID="$(echo "$CREATE_OUT" | python3 -c "
 import re, sys


### PR DESCRIPTION
…ution

Add VAST_USER env var (falls back to $USER, then "unknown") and pass a vast.ai --label of the form "<user>/<LABEL>/<utc-ts>" at create time so other users on a shared account can attribute running instances via `vastai show instances`. Destroy behavior is unchanged — still by-ID only.